### PR TITLE
Fix issue #23: unmanage windows unmapped by programs themselves

### DIFF
--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <array>
 #include <vector>
 #include <memory>
+#include <unordered_set>
 
 #include "action.h"
 #include "config.h"
@@ -58,6 +59,8 @@ class WindowManager {
   static int OnXError(Display* dpy, XErrorEvent* e);
   static int OnWmDetected(Display* dpy, XErrorEvent* e);
 
+  void Manage(Window window);
+  void Unmanage(Window window);
   void HandleAction(const Action& action);
 
   // Workspace manipulation
@@ -99,6 +102,13 @@ class WindowManager {
   std::vector<Window> docks_;
   std::vector<Window> notifications_;
 
+  // Some programs (e.g., WPS office, Steam) might unmap its window(s)
+  // but keep them in the background instead of destroying them. It is
+  // up to the programs (i.e., owner of the windows) when to reuse them,
+  // so we should not simply destroy these windows! We should store them
+  // somewhere instead.
+  std::unordered_set<Window> hidden_windows_;
+ 
   // Workspaces contain clients, where a client is a window that can be tiled
   // by the window manager.
   std::array<std::unique_ptr<Workspace>, WORKSPACE_COUNT> workspaces_;

--- a/src/workspace.cc
+++ b/src/workspace.cc
@@ -187,23 +187,19 @@ void Workspace::SetTilingDirection(TilingDirection tiling_direction) {
 
 
 void Workspace::MapAllClients() const {
-  for (const auto leaf : client_tree_.GetLeaves()) {
-    if (leaf != client_tree_.root_node()) {
-      leaf->client()->Map();
-    }
+  for (const auto c : GetClients()) {
+    c->Map();
   }
 }
 
 void Workspace::UnmapAllClients() const {
-  for (auto leaf : client_tree_.GetLeaves()) {
-    if (leaf != client_tree_.root_node()) {
-      leaf->client()->Unmap();
-    }
+  for (const auto c : GetClients()) {
+    c->Unmap();
   }
 }
 
 void Workspace::RaiseAllFloatingClients() const {
-  for (auto c : GetFloatingClients()) {
+  for (const auto c : GetFloatingClients()) {
     c->Raise();
   }
 }


### PR DESCRIPTION
This commit fixes issue #23.

Some programs (e.g., WPS office, Steam) might unmap its window(s)
but keep them in the background instead of destroying them immediately.
It is up to the programs (i.e., owner of the windows) when to reuse them,
so we should not simply destroy these windows, or these programs might
have undefined behaviors!

We should 'unmanage' these windows when they are unmapped and store
them somewhere (so that we know they're hidden, and might be reused
sometime in the future by their owner programs). When the owner programs
want to reuse these window (most likely via XConfigureRequest),
we will manage these window again.

The windows unmapped by a program itself will be stored here:
> std::unordered_set<Window> hidden_windows_;

Note: Only windows unmapped by their owner programs will be affected
by this commit, while windows unmapped by the user/wm will not.