### PR TITLE
stacktrace: only enable for glibc

### DIFF
--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -9,10 +9,13 @@ namespace wmderland {
 namespace segv {
 
 void InstallHandler(void (*Handler)(int)) {
+#ifdef __GLIBC__
   signal(SIGSEGV, Handler);
+#endif
 }
 
 void Handle(int) {
+#ifdef __GLIBC__
   void* array[STACKTRACE_FUNC_COUNT];
   size_t size = backtrace(array, STACKTRACE_FUNC_COUNT);
 
@@ -21,6 +24,7 @@ void Handle(int) {
   close(fd);
 
   exit(EXIT_FAILURE);
+#endif
 }
 
 }  // namespace segv

--- a/src/stacktrace.h
+++ b/src/stacktrace.h
@@ -3,10 +3,12 @@
 #define WMDERLAND_STACKTRACE_H_
 
 extern "C" {
+#include <stdlib.h>    // exit
+#ifdef __GLIBC__
 #include <execinfo.h>  // backtrace*
+#endif
 #include <fcntl.h>     // open
 #include <signal.h>    // signal
-#include <stdlib.h>    // exit
 #include <unistd.h>    // close
 }
 


### PR DESCRIPTION
backtrace() is a glibc extension, and doesn't work on other platforms like musl libc.