### PR TITLE
add windowfocus-follows-mouse feature #33

### DIFF
--- a/example/config
+++ b/example/config
@@ -16,12 +16,13 @@
 ; `set <Key> = <Value>` to set a builtin varaible
 ; `set $<Variable> = <Value>` to define your own variable
 ; -----------------------------------------------------------------------
-set gap_width = 12
+set gap_width = 10
 set border_width = 3
 set min_window_width = 100
 set min_window_height = 100
-set focused_color = ff4c5d70
+set focused_color = ff596e84
 set unfocused_color = ff394859
+set focus_follows_mouse = true
 set $Mod = Mod4
 
 
@@ -31,16 +32,16 @@ set $Mod = Mod4
 assign URxvt 1
 assign jetbrains-idea 2
 assign Google-chrome 3
+assign Firefox 3
 assign dolphin 4
 assign ark 4
 assign Et 5
 assign Wps 5
 assign Wpp 5
-assign Spotify 6
 assign vlc 6
-assign Gimp-2.10 7
+assign Popcorn-Time 6
+assign krita 7
 assign tiled 7
-assign Wine,steam.exe 8
 assign Steam 8
 assign PCSX2 8
 assign PPSSPPQt 8
@@ -53,6 +54,9 @@ assign Transmission 9
 ; [Floating Rules]
 ; Applications that should be floating by default
 ; -----------------------------------------------------------------------
+floating plasmashell true
+floating krunner true
+floating kcalc true
 floating systemsettings true
 floating SimpleScreenRecorder true
 floating Sxiv true
@@ -63,19 +67,22 @@ floating Gcolor2 true
 floating Steam true
 floating PCSX2 true
 floating Wine true
-floating Wine,steam.exe true
-floating Wine,tesv.exe true
 floating VirtualBox Machine true
 floating Vigilante true
 floating xfreerdp true
+floating steam_app_72850 true
+floating steam_app_105600 true
 floating com.hacklympics.main.Main true
+floating pyRollCall true
 
 
 ; [Fullscreen Rules]
 ; Applications that should be fullscreen by default
 ; -----------------------------------------------------------------------
 fullscreen Wine,maplelegendswindowed.exe true
-fullscreen Wine,tesv.exe true
+fullscreen insurgency_linux true
+fullscreen steam_app_72850 tesv_original.exe true
+fullscreen postal2-bin true
 
 
 ; [Prohibit Rules]
@@ -137,6 +144,7 @@ bindsym XF86AudioMute exec amixer -q -D pulse set Master toggle
 bindsym XF86AudioRaiseVolume exec amixer -q -D pulse set Master 5%+ unmute
 bindsym XF86AudioLowerVolume exec amixer -q -D pulse set Master 5%- unmute
 bindsym XF86PowerOff exec qdbus org.kde.ksmserver /KSMServer org.kde.KSMServerInterface.logout -1 -1 -1
+bindsym $Mod+Escape exec toggle_screen.sh
 
 bindsym Control+Shift+3 exec scrotutl -f
 bindsym Control+Shift+4 exec scrotutl -s
@@ -150,7 +158,7 @@ bindsym $Mod+Return goto_workspace 1; exec urxvt
 ; Applications to execute when WM starts up (DON'T append '&' at the end)
 ; -----------------------------------------------------------------------
 exec pulseaudio --start --log-target=syslog
-exec ~/.config/mpd/launch.sh
+exec_on_reload ~/.config/mpd/launch.sh
 exec dunst
 exec dispad
 exec displayctl

--- a/src/client.cc
+++ b/src/client.cc
@@ -25,7 +25,6 @@ Client::Client(Display* dpy, Window window, Workspace* workspace)
   Client::mapper_[window] = this;
   SetBorderWidth(workspace->config()->border_width());
   SetBorderColor(workspace->config()->unfocused_color());
-  XSelectInput(dpy, window, EnterWindowMask);
 }
 
 Client::~Client() {
@@ -77,6 +76,10 @@ void Client::SetBorderWidth(unsigned int width) const {
 
 void Client::SetBorderColor(unsigned long color) const {
   XSetWindowBorder(dpy_, window_, color);
+}
+
+void Client::SelectInput(long input_mask) const {
+  XSelectInput(dpy_, window_, input_mask);
 }
 
 XWindowAttributes Client::GetXWindowAttributes() const {

--- a/src/client.cc
+++ b/src/client.cc
@@ -25,7 +25,7 @@ Client::Client(Display* dpy, Window window, Workspace* workspace)
   Client::mapper_[window] = this;
   SetBorderWidth(workspace->config()->border_width());
   SetBorderColor(workspace->config()->unfocused_color());
-  XSelectInput(dpy, window, EnterWindowMask | LeaveWindowMask);
+  XSelectInput(dpy, window, EnterWindowMask);
 }
 
 Client::~Client() {

--- a/src/client.cc
+++ b/src/client.cc
@@ -25,7 +25,6 @@ Client::Client(Display* dpy, Window window, Workspace* workspace)
   Client::mapper_[window] = this;
   SetBorderWidth(workspace->config()->border_width());
   SetBorderColor(workspace->config()->unfocused_color());
-  SelectInput(EnterWindowMask);
 }
 
 Client::~Client() {

--- a/src/client.cc
+++ b/src/client.cc
@@ -25,6 +25,7 @@ Client::Client(Display* dpy, Window window, Workspace* workspace)
   Client::mapper_[window] = this;
   SetBorderWidth(workspace->config()->border_width());
   SetBorderColor(workspace->config()->unfocused_color());
+  XSelectInput(dpy, window, EnterWindowMask | LeaveWindowMask);
 }
 
 Client::~Client() {

--- a/src/client.cc
+++ b/src/client.cc
@@ -25,6 +25,7 @@ Client::Client(Display* dpy, Window window, Workspace* workspace)
   Client::mapper_[window] = this;
   SetBorderWidth(workspace->config()->border_width());
   SetBorderColor(workspace->config()->unfocused_color());
+  SelectInput(EnterWindowMask);
 }
 
 Client::~Client() {

--- a/src/client.h
+++ b/src/client.h
@@ -42,6 +42,7 @@ class Client {
   void SetInputFocus() const;
   void SetBorderWidth(unsigned int width) const;
   void SetBorderColor(unsigned long color) const;
+  void SelectInput(long input_mask) const;
   XWindowAttributes GetXWindowAttributes() const;
 
   Window window() const;

--- a/src/config.cc
+++ b/src/config.cc
@@ -103,6 +103,10 @@ unsigned long Config::unfocused_color() const {
   return unfocused_color_;
 }
 
+bool Config::focus_follows_mouse() const {
+  return focus_follows_mouse_;
+}
+
 const map<pair<unsigned int, KeyCode>, vector<Action>>& Config::keybind_rules() const {
   return keybind_rules_;
 }
@@ -171,6 +175,7 @@ ifstream& operator>>(ifstream& ifs, Config& config) {
   config.min_window_height_ = MIN_WINDOW_HEIGHT;
   config.focused_color_ = DEFAULT_FOCUSED_COLOR;
   config.unfocused_color_ = DEFAULT_UNFOCUSED_COLOR;
+  config.focus_follows_mouse_ = DEFAULT_FOCUS_FOLLOWS_MOUSE;
 
   config.symtab_.clear();
   config.spawn_rules_.clear();
@@ -224,6 +229,8 @@ ifstream& operator>>(ifstream& ifs, Config& config) {
             config.focused_color_ = std::stoul(value, nullptr, 16);
           } else if (key == "unfocused_color") {
             config.unfocused_color_ = std::stoul(value, nullptr, 16);
+          } else if (key == "focus_follows_mouse") {
+            stringstream(tokens.back()) >> std::boolalpha >> config.focus_follows_mouse_;
           } else {
             WM_LOG(ERROR, "config: unrecognized identifier: " << key);
           }

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -57,6 +57,7 @@ extern "C" {
 #define DEFAULT_BORDER_WIDTH 3
 #define DEFAULT_FOCUSED_COLOR 0xffffffff
 #define DEFAULT_UNFOCUSED_COLOR 0xff41485f
+#define DEFAULT_FOCUS_FOLLOWS_MOUSE true
 
 #define VARIABLE_PREFIX "$"
 #define DEFAULT_EXIT_KEY "Mod4+Shift+Escape"
@@ -81,6 +82,7 @@ class Config {
   unsigned int min_window_height() const;
   unsigned long focused_color() const;
   unsigned long unfocused_color() const;
+  bool focus_follows_mouse() const;
   const std::map<std::pair<unsigned int, KeyCode>, std::vector<Action>>& keybind_rules() const;
   const std::vector<std::string>& autostart_cmds() const;
   const std::vector<std::string>& autostart_cmds_on_reload() const;
@@ -113,6 +115,7 @@ class Config {
   unsigned int min_window_height_;
   unsigned long focused_color_;
   unsigned long unfocused_color_;
+  bool focus_follows_mouse_;
 
   // symtab: for storing user-declared identifiers.
   // spawn_rules_: spawn certain apps in certain workspaces.

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -444,6 +444,7 @@ void WindowManager::OnEnterNotify(const XEnterWindowEvent& e) {
 
   workspaces_[current_]->UnsetFocusedClient();
   workspaces_[current_]->SetFocusedClient(e.window);
+  ArrangeWindows();
 }
 
 void WindowManager::OnClientMessage(const XClientMessageEvent& e) {

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -440,6 +440,10 @@ void WindowManager::OnMotionNotify(const XButtonEvent& e) {
 }
 
 void WindowManager::OnEnterNotify(const XEnterWindowEvent& e) {
+  if (!config_->focus_follows_mouse()) {
+    return;
+  }
+
   HAS_CLIENT_OR_RETURN(e.window);
 
   workspaces_[current_]->UnsetFocusedClient();

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -274,15 +274,13 @@ void WindowManager::ArrangeWindows() const {
     MapDocks();
     wm_utils::ClearNetActiveWindow();
     return;
-  } else {
-    wm_utils::SetNetActiveWindow(focused_client->window());
   }
+
+  wm_utils::SetNetActiveWindow(focused_client->window());
 
   if (workspaces_[current_]->is_fullscreen()) {
     UnmapDocks();
-    focused_client->SetBorderWidth(0);
-    focused_client->MoveResize(0, 0, GetDisplayResolution());
-    focused_client->Raise();
+    workspaces_[current_]->SetFocusedClient(focused_client->window());
   } else {
     MapDocks();
     workspaces_[current_]->MapAllClients();
@@ -692,21 +690,23 @@ void WindowManager::SetFullscreen(Window window, bool fullscreen) {
 
   c->set_fullscreen(fullscreen);
   c->workspace()->set_fullscreen(fullscreen);
-  c->SetBorderWidth((fullscreen) ? 0 : config_->border_width());
 
   if (fullscreen) {
     UnmapDocks();
     c->set_attr_cache(c->GetXWindowAttributes());
-    c->MoveResize(0, 0, GetDisplayResolution());
     c->workspace()->UnmapAllClients();
     c->Map();
+    c->SetBorderWidth(0);
+    c->MoveResize(0, 0, GetDisplayResolution());
     c->workspace()->SetFocusedClient(c->window());
   } else {
     MapDocks();
     const XWindowAttributes& attr = c->attr_cache();
+    c->SetBorderWidth(config_->border_width());
     c->MoveResize(attr.x, attr.y, attr.width, attr.height);
-    ArrangeWindows();
   }
+
+  ArrangeWindows();
 
   // Update window's _NET_WM_STATE_FULLSCREEN property.
   // If the window is set to be NOT fullscreen, we will simply write a nullptr

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -406,11 +406,11 @@ void WindowManager::OnButtonPress(const XButtonEvent& e) {
   c->workspace()->RaiseAllFloatingClients();
 
   if (c->is_floating() && !c->is_fullscreen()) {
-    XDefineCursor(dpy_, root_window_, cursors_[e.button]);
-
     c->Raise();
     c->set_attr_cache(c->GetXWindowAttributes());
+
     btn_pressed_event_ = e;
+    XDefineCursor(dpy_, root_window_, cursors_[e.button]);
   }
 }
 
@@ -418,14 +418,15 @@ void WindowManager::OnButtonRelease(const XButtonEvent&) {
   Client* c = nullptr;
   GET_CLIENT_OR_RETURN(btn_pressed_event_.subwindow, c);
 
+  c->workspace()->EnableFocusFollowsMouse();
+  
   if (c->is_floating()) {
     XWindowAttributes attr = wm_utils::GetXWindowAttributes(btn_pressed_event_.subwindow);
     cookie_.Put(c->window(), {attr.x, attr.y, attr.width, attr.height});
-  }
 
-  c->workspace()->EnableFocusFollowsMouse();
-  btn_pressed_event_.subwindow = None;
-  XDefineCursor(dpy_, root_window_, cursors_[CURSOR_NORMAL]);
+    btn_pressed_event_.subwindow = None;
+    XDefineCursor(dpy_, root_window_, cursors_[CURSOR_NORMAL]);
+  }
 }
 
 void WindowManager::OnMotionNotify(const XButtonEvent& e) {

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -56,6 +56,7 @@ extern "C" {
 #define CURSOR_RESIZE 3
 
 using std::pair;
+using std::vector;
 
 namespace wmderland {
 
@@ -278,6 +279,12 @@ void WindowManager::ArrangeWindows() const {
 
   wm_utils::SetNetActiveWindow(focused_client->window());
 
+  // Pause receiving OnEnterWindowEvents for all windows in current workspace.
+  vector<Client*> clients = workspaces_[current_]->GetClients();
+  for (const auto c : clients) {
+    c->SelectInput(None);
+  }
+
   if (workspaces_[current_]->is_fullscreen()) {
     UnmapDocks();
     workspaces_[current_]->SetFocusedClient(focused_client->window());
@@ -288,6 +295,11 @@ void WindowManager::ArrangeWindows() const {
     workspaces_[current_]->SetFocusedClient(focused_client->window());
     workspaces_[current_]->RaiseAllFloatingClients();
     RaiseNotifications();
+  }
+
+  // Resume receiving OnEnterWindowEvents for all windows in current workspace.
+  for (const auto c : clients) {
+    c->SelectInput(EnterWindowMask);
   }
 }
 
@@ -342,7 +354,6 @@ void WindowManager::OnMapNotify(const XMapEvent& e) {
   Client* c = nullptr;
   GET_CLIENT_OR_RETURN(e.window, c);
 
-  c->SelectInput(EnterWindowMask);
   c->set_mapped(true);
 }
 
@@ -353,7 +364,6 @@ void WindowManager::OnUnmapNotify(const XUnmapEvent& e) {
   // Some program unmaps their windows but does not remove them,
   // so if this window has just been unmapped, but it was not unmapped
   // by the user, then we will remove them for user.
-  c->SelectInput(None);
   c->set_mapped(false);
 
   if (c->has_unmap_req_from_wm()) {
@@ -513,11 +523,6 @@ void WindowManager::Manage(Window window) {
 
   Client* prev_focused_client = workspaces_[target]->GetFocusedClient();
 
-  // Pause the receival of OnEnterNotify events.
-  if (prev_focused_client) {
-    prev_focused_client->SelectInput(None);
-  }
-
   workspaces_[target]->UnsetFocusedClient();
   workspaces_[target]->Add(window);
   UpdateClientList();  // update NET_CLIENT_LIST
@@ -545,11 +550,6 @@ void WindowManager::Manage(Window window) {
 
   if (target == current_ && !workspaces_[current_]->is_fullscreen()) {
     ArrangeWindows();
-  }
-
-  // Restart the receival of OnEnterNotify events.
-  if (prev_focused_client) {
-    prev_focused_client->SelectInput(EnterWindowMask);
   }
 }
 

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -694,6 +694,7 @@ void WindowManager::SetFullscreen(Window window, bool fullscreen) {
     c->set_attr_cache(c->GetXWindowAttributes());
     c->workspace()->UnmapAllClients();
     c->Map();
+    c->SetBorderWidth(0);  // Weird workaround for "doubled visioned" KDE logout screen :(
   } else {
     const XWindowAttributes& attr = c->attr_cache();
     c->SetBorderWidth(config_->border_width());

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -283,7 +283,9 @@ void WindowManager::ArrangeWindows() const {
 
   if (workspaces_[current_]->is_fullscreen()) {
     UnmapDocks();
-    workspaces_[current_]->SetFocusedClient(focused_client->window());
+    focused_client->SetBorderWidth(0);
+    focused_client->MoveResize(0, 0, GetDisplayResolution());
+    focused_client->workspace()->SetFocusedClient(focused_client->window());
   } else {
     MapDocks();
     workspaces_[current_]->MapAllClients();
@@ -690,15 +692,10 @@ void WindowManager::SetFullscreen(Window window, bool fullscreen) {
   c->workspace()->set_fullscreen(fullscreen);
 
   if (fullscreen) {
-    UnmapDocks();
     c->set_attr_cache(c->GetXWindowAttributes());
     c->workspace()->UnmapAllClients();
     c->Map();
-    c->SetBorderWidth(0);
-    c->MoveResize(0, 0, GetDisplayResolution());
-    c->workspace()->SetFocusedClient(c->window());
   } else {
-    MapDocks();
     const XWindowAttributes& attr = c->attr_cache();
     c->SetBorderWidth(config_->border_width());
     c->MoveResize(attr.x, attr.y, attr.width, attr.height);

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -220,6 +220,12 @@ void WindowManager::Run() {
       case MotionNotify:
         OnMotionNotify(event.xbutton);
         break;
+      case EnterNotify:
+        OnEnterNotify(event.xcrossing);
+        break;
+      case LeaveNotify:
+        OnLeaveNotify(event.xcrossing);
+        break;
       case ClientMessage:
         OnClientMessage(event.xclient);
         break;
@@ -416,6 +422,14 @@ void WindowManager::OnMotionNotify(const XButtonEvent& e) {
   new_width = (new_width < min_width) ? min_width : new_width;
   new_height = (new_height < min_height) ? min_height : new_height;
   c->MoveResize(new_x, new_y, new_width, new_height);
+}
+
+void WindowManager::OnEnterNotify(const XEnterWindowEvent& e) {
+  WM_LOG(INFO, "enter!");
+}
+
+void WindowManager::OnLeaveNotify(const XEnterWindowEvent& e) {
+  WM_LOG(INFO, "leave!");
 }
 
 void WindowManager::OnClientMessage(const XClientMessageEvent& e) {

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -256,9 +256,6 @@ void WindowManager::Run() {
       case EnterNotify:
         OnEnterNotify(event.xcrossing);
         break;
-      case LeaveNotify:
-        OnLeaveNotify(event.xcrossing);
-        break;
       case ClientMessage:
         OnClientMessage(event.xclient);
         break;
@@ -443,16 +440,10 @@ void WindowManager::OnMotionNotify(const XButtonEvent& e) {
 }
 
 void WindowManager::OnEnterNotify(const XEnterWindowEvent& e) {
-  WM_LOG(INFO, "enter!");
-
   HAS_CLIENT_OR_RETURN(e.window);
 
   workspaces_[current_]->UnsetFocusedClient();
   workspaces_[current_]->SetFocusedClient(e.window);
-}
-
-void WindowManager::OnLeaveNotify(const XEnterWindowEvent& e) {
-  WM_LOG(INFO, "leave!");
 }
 
 void WindowManager::OnClientMessage(const XClientMessageEvent& e) {

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -444,6 +444,11 @@ void WindowManager::OnMotionNotify(const XButtonEvent& e) {
 
 void WindowManager::OnEnterNotify(const XEnterWindowEvent& e) {
   WM_LOG(INFO, "enter!");
+
+  HAS_CLIENT_OR_RETURN(e.window);
+
+  workspaces_[current_]->UnsetFocusedClient();
+  workspaces_[current_]->SetFocusedClient(e.window);
 }
 
 void WindowManager::OnLeaveNotify(const XEnterWindowEvent& e) {

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -348,6 +348,7 @@ void WindowManager::OnMapNotify(const XMapEvent& e) {
   Client* c = nullptr;
   GET_CLIENT_OR_RETURN(e.window, c);
 
+  c->SelectInput(EnterWindowMask);
   c->set_mapped(true);
 }
 
@@ -358,6 +359,7 @@ void WindowManager::OnUnmapNotify(const XUnmapEvent& e) {
   // Some program unmaps their windows but does not remove them,
   // so if this window has just been unmapped, but it was not unmapped
   // by the user, then we will remove them for user.
+  c->SelectInput(None);
   c->set_mapped(false);
 
   if (c->has_unmap_req_from_wm()) {

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -355,12 +355,12 @@ void WindowManager::OnMapNotify(const XMapEvent& e) {
 }
 
 void WindowManager::OnUnmapNotify(const XUnmapEvent& e) {
+  // Some program unmaps their windows but does not destroy them,
+  // so if this window has just been unmapped, but it was not unmapped
+  // by the user, then we will remove them for user.
   Client* c = nullptr;
   GET_CLIENT_OR_RETURN(e.window, c);
 
-  // Some program unmaps their windows but does not remove them,
-  // so if this window has just been unmapped, but it was not unmapped
-  // by the user, then we will remove them for user.
   c->SelectInput(None);
   c->set_mapped(false);
 
@@ -522,7 +522,6 @@ void WindowManager::Manage(Window window) {
   }
 
   Client* prev_focused_client = workspaces_[target]->GetFocusedClient();
-
   workspaces_[target]->UnsetFocusedClient();
   workspaces_[target]->Add(window);
   UpdateClientList();  // update NET_CLIENT_LIST

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -53,6 +53,8 @@ class WindowManager {
   void OnButtonPress(const XButtonEvent& e);
   void OnButtonRelease(const XButtonEvent& e);
   void OnMotionNotify(const XButtonEvent& e);
+  void OnEnterNotify(const XEnterWindowEvent& e);
+  void OnLeaveNotify(const XLeaveWindowEvent& e);
   void OnClientMessage(const XClientMessageEvent& e);
   void OnConfigReload();
   static int OnXError(Display* dpy, XErrorEvent* e);

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -54,7 +54,6 @@ class WindowManager {
   void OnButtonRelease(const XButtonEvent& e);
   void OnMotionNotify(const XButtonEvent& e);
   void OnEnterNotify(const XEnterWindowEvent& e);
-  void OnLeaveNotify(const XLeaveWindowEvent& e);
   void OnClientMessage(const XClientMessageEvent& e);
   void OnConfigReload();
   static int OnXError(Display* dpy, XErrorEvent* e);

--- a/src/workspace.cc
+++ b/src/workspace.cc
@@ -208,9 +208,11 @@ void Workspace::MapAllClients() const {
   }
 }
 
-void Workspace::UnmapAllClients() const {
+void Workspace::UnmapAllClients(Window except_window) const {
   for (const auto c : GetClients()) {
-    c->Unmap();
+    if (c->window() != except_window) {
+      c->Unmap();
+    }
   }
 }
 
@@ -360,7 +362,6 @@ vector<Client*> Workspace::GetTilingClients() const {
                 clients.end());
   return clients;
 }
-
 
 Config* Workspace::config() const {
   return config_;

--- a/src/workspace.cc
+++ b/src/workspace.cc
@@ -333,7 +333,6 @@ void Workspace::Navigate(Action::Type focus_action_type) {
       }
       UnsetFocusedClient();
       SetFocusedClient(node->client()->window());
-      client_tree_.set_current_node(node);
       WindowManager::GetInstance()->ArrangeWindows();
       return;
     } else if (node->parent() == client_tree_.root_node()) {

--- a/src/workspace.cc
+++ b/src/workspace.cc
@@ -244,51 +244,24 @@ void Workspace::UnsetFocusedClient() const {
   }
 }
 
-Client* Workspace::GetFocusedClient() const {
-  if (!client_tree_.current_node()) {
-    return nullptr;
-  }
-  return client_tree_.current_node()->client();
-}
-
-Client* Workspace::GetClient(Window window) const {
-  // We'll get the corresponding client using client mapper
-  // whose time complexity is O(1).
-  auto it = Client::mapper_.find(window);
-  if (it == Client::mapper_.end()) {
-    return nullptr;
+void Workspace::DisableFocusFollowsMouse() const {
+  if (!config_->focus_follows_mouse()) {
+    return;
   }
 
-  // But we have to check if it belongs to current workspace!
-  Client* c = it->second;
-  return (c->workspace() == this) ? c : nullptr;
-}
-
-vector<Client*> Workspace::GetClients() const {
-  vector<Client*> clients;
-
-  for (auto leaf : client_tree_.GetLeaves()) {
-    if (leaf != client_tree_.root_node()) {
-      clients.push_back(leaf->client());
-    }
+  for (const auto c : GetClients()) {
+    c->SelectInput(None);
   }
-  return clients;
 }
 
-vector<Client*> Workspace::GetFloatingClients() const {
-  vector<Client*> clients = GetClients();
-  clients.erase(std::remove_if(clients.begin(), clients.end(),
-                               [](Client* c) { return !c->is_floating(); }),
-                clients.end());
-  return clients;
-}
+void Workspace::EnableFocusFollowsMouse() const {
+  if (!config_->focus_follows_mouse()) {
+    return;
+  }
 
-vector<Client*> Workspace::GetTilingClients() const {
-  vector<Client*> clients = GetClients();
-  clients.erase(std::remove_if(clients.begin(), clients.end(),
-                               [](Client* c) { return c->is_floating(); }),
-                clients.end());
-  return clients;
+  for (const auto c : GetClients()) {
+    c->SelectInput(EnterWindowMask);
+  }
 }
 
 void Workspace::Navigate(Action::Type focus_action_type) {
@@ -340,6 +313,54 @@ void Workspace::Navigate(Action::Type focus_action_type) {
     }
   }
 }
+
+Client* Workspace::GetFocusedClient() const {
+  if (!client_tree_.current_node()) {
+    return nullptr;
+  }
+  return client_tree_.current_node()->client();
+}
+
+Client* Workspace::GetClient(Window window) const {
+  // We'll get the corresponding client using client mapper
+  // whose time complexity is O(1).
+  auto it = Client::mapper_.find(window);
+  if (it == Client::mapper_.end()) {
+    return nullptr;
+  }
+
+  // But we have to check if it belongs to current workspace!
+  Client* c = it->second;
+  return (c->workspace() == this) ? c : nullptr;
+}
+
+vector<Client*> Workspace::GetClients() const {
+  vector<Client*> clients;
+
+  for (auto leaf : client_tree_.GetLeaves()) {
+    if (leaf != client_tree_.root_node()) {
+      clients.push_back(leaf->client());
+    }
+  }
+  return clients;
+}
+
+vector<Client*> Workspace::GetFloatingClients() const {
+  vector<Client*> clients = GetClients();
+  clients.erase(std::remove_if(clients.begin(), clients.end(),
+                               [](Client* c) { return !c->is_floating(); }),
+                clients.end());
+  return clients;
+}
+
+vector<Client*> Workspace::GetTilingClients() const {
+  vector<Client*> clients = GetClients();
+  clients.erase(std::remove_if(clients.begin(), clients.end(),
+                               [](Client* c) { return c->is_floating(); }),
+                clients.end());
+  return clients;
+}
+
 
 Config* Workspace::config() const {
   return config_;

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -32,6 +32,9 @@ class Workspace {
   void SetFocusedClient(Window window);
   void UnsetFocusedClient() const;
 
+  void DisableFocusFollowsMouse() const;
+  void EnableFocusFollowsMouse() const;
+
   void Navigate(Action::Type navigate_action_type);
   Client* GetFocusedClient() const;
   Client* GetClient(Window window) const;

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -27,7 +27,7 @@ class Workspace {
   void SetTilingDirection(TilingDirection tiling_direction);
 
   void MapAllClients() const;
-  void UnmapAllClients() const;
+  void UnmapAllClients(Window except_window = None) const;
   void RaiseAllFloatingClients() const;
   void SetFocusedClient(Window window);
   void UnsetFocusedClient() const;


### PR DESCRIPTION
Feature request: #33 

This feature works exactly the same as i3wm's, and it is toggle-able via config file:
```
set focus_follows_mouse = true
``` 

By default, this feature is enabled. :smile: